### PR TITLE
Add Meshery to Cluster Managers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Tools
 -	[Mesos](https://mesos.apache.org/)
 -	[Mesosphere](https://mesosphere.com/)
 -	[Swarm](https://docs.docker.com/swarm/)
-
+-	[Meshery](https://meshery.io) - Cloud native management plane for Kubernetes and service meshes
 ### Source Control
 
 -	[Git](https://git-scm.com/) - The most popular distributed version control system.


### PR DESCRIPTION
Added Meshery to the Cluster Managers section.
Meshery is a CNCF project and cloud native
management plane for Kubernetes with 10,000+
GitHub stars.

Relates to: meshery/meshery#13426